### PR TITLE
chore(deps): Update Node version in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/setup-node@v2
       with:
-        node-version: '14.20'
+        node-version: '20.15'
     - name: Checkout
       uses: actions/checkout@v2
     - name: Prepare demo-app


### PR DESCRIPTION
This pull request includes a change to the CI workflow configuration to update the Node.js version used in the setup.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL24-R24): Updated the Node.js version from `14.20` to `20.15` in the `setup-node` action.